### PR TITLE
Avoid reflected XSS security vulnerability

### DIFF
--- a/classes/widgets/search-properties.php
+++ b/classes/widgets/search-properties.php
@@ -70,7 +70,7 @@ class REM_Search_Property_Widget extends WP_Widget {
 					<form method="get" action="<?php echo get_permalink( $result_page ); ?>">
 						<?php if(isset($search_field)){ ?>
 							<div class="col-md-12 space-div">
-								<input class="form-control" value="<?php echo (isset($_GET['search_property'])) ? $_GET['search_property'] : '' ; ?>" type="text" name="search_property" id="keywords" placeholder="<?php _e( 'Keywords','real-estate-manager' ); ?>" />
+								<input class="form-control" value="<?php echo (isset($_GET['search_property'])) ? esc_attr($_GET['search_property']) : '' ; ?>" type="text" name="search_property" id="keywords" placeholder="<?php _e( 'Keywords','real-estate-manager' ); ?>" />
 							</div>
 						<?php } else {
 							echo '<input value="" type="hidden" name="search_property" />';

--- a/core.functions.php
+++ b/core.functions.php
@@ -713,7 +713,7 @@ function rem_render_property_search_fields($field, $display = 'widget'){
 					?>
 			</select>
 		<?php } else { ?>
-			<input class="form-control" type="text" placeholder="<?php echo $field['title']; ?>" name="<?php echo $field['key']; ?>" id="<?php echo $field['key']; ?>" value="<?php echo (isset($_GET[$field['key']])) ? $_GET[$field['key']] : '' ; ?>"/>
+			<input class="form-control" type="text" placeholder="<?php echo $field['title']; ?>" name="<?php echo $field['key']; ?>" id="<?php echo $field['key']; ?>" value="<?php echo (isset($_GET[$field['key']])) ? esc_attr($_GET[$field['key']]) : '' ; ?>"/>
 		<?php }		
 	} elseif ($field['key'] == '') { ?>
 		
@@ -732,7 +732,7 @@ function rem_render_property_search_fields($field, $display = 'widget'){
 					?>
 			</select>
 		<?php } else { ?>
-			<input placeholder="<?php echo $field['title']; ?>" class="form-control" type="<?php echo $field['type']; ?>" name="<?php echo $field['key']; ?>" id="<?php echo $field['key']; ?>" value="<?php echo (isset($_GET[$field['key']])) ? $_GET[$field['key']] : '' ; ?>"/>
+			<input placeholder="<?php echo $field['title']; ?>" class="form-control" type="<?php echo $field['type']; ?>" name="<?php echo $field['key']; ?>" id="<?php echo $field['key']; ?>" value="<?php echo (isset($_GET[$field['key']])) ? esc_attr($_GET[$field['key']]) : '' ; ?>"/>
 		<?php }
 	}
 }
@@ -759,9 +759,9 @@ function rem_render_price_range_field($display = 'widget'){
 			<label><?php _e( 'Price', 'real-estate-manager' ); ?></label>
 		<?php } ?>
 	<div class="row">
-		<div class="col-xs-5"><input type="text" class="form-control" name="price_min" placeholder="<?php _e( 'Min', 'real-estate-manager' ); ?>" value="<?php echo (isset($_GET['price_min'])) ? $_GET['price_min'] : '' ; ?>"></div>
+		<div class="col-xs-5"><input type="text" class="form-control" name="price_min" placeholder="<?php _e( 'Min', 'real-estate-manager' ); ?>" value="<?php echo (isset($_GET['price_min'])) ? esc_attr($_GET['price_min']) : '' ; ?>"></div>
 		<div class="col-xs-2 text-center"><strong class="price-sep"><?php echo $price_symbol; ?></strong></div>
-		<div class="col-xs-5"><input type="text" class="form-control" name="price_max" placeholder="<?php _e( 'Max', 'real-estate-manager' ); ?>" value="<?php echo (isset($_GET['price_max'])) ? $_GET['price_max'] : '' ; ?>"></div>
+		<div class="col-xs-5"><input type="text" class="form-control" name="price_max" placeholder="<?php _e( 'Max', 'real-estate-manager' ); ?>" value="<?php echo (isset($_GET['price_max'])) ? esc_attr($_GET['price_max']) : '' ; ?>"></div>
 	</div>
 	<?php } ?>
 <?php }

--- a/shortcodes/edit-property.php
+++ b/shortcodes/edit-property.php
@@ -109,7 +109,7 @@ $p_tags = wp_get_post_terms( $_GET['property_id'] ,'rem_property_tag' );
 						<div id="position"><i class="fa fa-map-marker"></i> <?php _e( 'Drag the pin to the location on the map', 'real-estate-manager' ); ?></div>
 					</div>
 					<br>
-					<input type="hidden" name="property_id" value="<?php echo $_GET['property_id']; ?>">
+					<input type="hidden" name="property_id" value="<?php echo esc_attr($_GET['property_id']); ?>">
 					<input class="btn btn-default" type="submit" value="<?php _e( 'Save Changes', 'real-estate-manager' ); ?>">
 					<br>
 					<br>

--- a/shortcodes/list/list.php
+++ b/shortcodes/list/list.php
@@ -6,7 +6,7 @@ if ( $the_query->have_posts() ) {
 	<div class="row rem-topbar">
 		<form method="GET" action="#">
 		<div class="col-sm-3 col-xs-8">
-			<input type="hidden" name="list_style" value="<?php echo (isset($_GET['list_style'])) ? $_GET['list_style'] : '' ; ?>">
+			<input type="hidden" name="list_style" value="<?php echo (isset($_GET['list_style'])) ? esc_attr($_GET['list_style']) : '' ; ?>">
 			<select class="form-control" name="sort_by" onchange="this.form.submit()">
 				<?php
 					$sorting_options = $this->lists_sorting_options();

--- a/shortcodes/simple-search.php
+++ b/shortcodes/simple-search.php
@@ -2,7 +2,7 @@
     <div class="rem-simple-search" style="max-width: <?php echo $width; ?>; margin:0 auto;border-color: <?php echo $border_color; ?> !important;">
         <form method="GET" action="<?php echo $results_page; ?>">
             <div class="input-group">
-                <input name="simple_search" type="text" class="form-control input-lg" value="<?php echo (isset($_GET['simple_search'])) ? $_GET['simple_search'] : '' ; ?>" placeholder="<?php echo $placeholder; ?>" />
+                <input name="simple_search" type="text" class="form-control input-lg" value="<?php echo (isset($_GET['simple_search'])) ? esc_attr($_GET['simple_search']) : '' ; ?>" placeholder="<?php echo $placeholder; ?>" />
                 <span class="input-group-btn">
                     <button class="btn btn-info btn-lg" type="submit" style="border-color: <?php echo $border_color; ?> !important;">
                         <?php echo $search_icon; ?>


### PR DESCRIPTION
The change avoids [reflected XSS](https://security.stackexchange.com/questions/65142/what-is-reflected-xss) in some input fields.

Never echo raw user input as obtained from user's parameters (`$_GET`, `$_POST`, `$_REQUEST`). Always wrap it in [`esc_attr()`](https://developer.wordpress.org/reference/functions/esc_attr/) (or similar; Wordpress-specific) or [`htmlspecialchars()`](http://php.net/manual/en/function.htmlspecialchars.php) (PHP in general).

See: https://developer.wordpress.org/plugins/security/securing-output/